### PR TITLE
Add XS0F-PMA smoke detector to supported device types

### DIFF
--- a/drivers/smoke-detector/driver.js
+++ b/drivers/smoke-detector/driver.js
@@ -211,12 +211,14 @@ class SmokeDetectorDriver extends Homey.Driver {
           //   - SC06-WX, SC07-WX, SC07-MR: Smoke/CO Combo (WiFi)
           //   - XP02S-MR, XP0A-MR, XP0A-iR: Smoke/CO Combo
           //   - SD11-MR: Smoke only
+          //   - XS0F-PMA: 230V smoke detector with RFM2300ZW-B RF module
           // Exclude: Heat (XH), Water (SWS), Temp (STH), Base Stations (SBS), CO-only (XC without smoke)
           const smokeTypes = [
             'XS01-M', 'XS01-WX', 'XS03-iWX', 'XS03-WX', 'XS0B-MR', 'XS0B-iR', 'XS0D-MR',
             'SC06-WX', 'SC07-WX', 'SC07-MR',
             'XP02S-MR', 'XP0A-MR', 'XP0A-iR', 'XP0A',
-            'SD11-MR'
+            'SD11-MR',
+            'XS0F-PMA'
           ];
           
           if (!smokeTypes.some(t => deviceType.toUpperCase().includes(t.toUpperCase()))) {


### PR DESCRIPTION
## Summary

This PR adds the **XS0F-PMA** (230V mains-powered smoke detector with the
RFM2300ZW-B RF module) to the `smokeTypes` whitelist in
`drivers/smoke-detector/driver.js`.

When paired to an SBS50 base station, the X-Sense cloud reports this device
as a regular child device with `deviceType: "XS0F-PMA"`, using the same
`2nd_mainpage` shadow structure as the already supported RF detectors
(XS01-M, XS0B-MR, etc.). The only thing preventing pairing was the
whitelist filter in the `list_devices` handler.

## Testing

Tested on a Homey Pro with an SBS50 (fw v1.7.3) and five XS0F-PMA units,
alongside two XS01-M and one XC01-M:

- All five XS0F-PMA detectors appear in the pairing list and pair successfully
- Battery (`batInfo`), RF level (`rfLevel`) and online status are reported correctly
- Shadow status structure (anonymized):

```json
"<SN>": {
  "type": "XS0F-PMA",
  "batInfo": "3",
  "acBreak": "0",
  "baseRemove": "0",
  "rfLevel": "3",
  "online": "1",
  "isLifeEnd": "0",
  "status": {
    "alarmStatus": "0",
    "initiativeAlarm": "0",
    "muteStatus": "0",
    "alarmOccur": "0"
  }
}
```

## Notes

The XS0F-PMA shadow exposes two fields not present on battery-powered
detectors: `acBreak` (mains power failure) and `baseRemove` (detector
removed from mounting base). These are not mapped to capabilities yet —
they could be useful additions for this device type in a future change,
since mains failure is particularly relevant for a 230V detector.