### PR TITLE
Fix timestamps and duplicate device updates

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.xsense.svenm",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "name": {

--- a/.homeycompose/capabilities/measure_last_seen.json
+++ b/.homeycompose/capabilities/measure_last_seen.json
@@ -1,8 +1,8 @@
 {
     "type": "string",
     "title": {
-        "en": "Last Seen",
-        "de": "Zuletzt gesehen"
+        "en": "Last Device Report",
+        "de": "Letzter Gerätebericht"
     },
     "getable": true,
     "setable": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.1.13
+
+- Correct X-Sense compact timestamps and rename the value to "Last Device Report".
+- Coalesce duplicate station and temperature updates.
+- Ignore unrelated updates in device listeners without noisy logs.
+- Skip fallback polling while MQTT is healthy for all active houses.
+
 ## Version 1.1.7
 
 ### 🔧 Bug Fixes

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 
 const Homey = require('homey');
 const XSenseAPI = require('./lib/XSenseAPI');
+const { shouldPollForMQTT } = require('./lib/MQTTPollingPolicy');
 
 class XSenseApp extends Homey.App {
   /**
@@ -359,6 +360,7 @@ class XSenseApp extends Homey.App {
       try {
         await client.init();
         this.apiClients.set(key, client);
+        this.lastControlPoll.set(key, Date.now());
         return client;
       } catch (error) {
         this.apiClients.delete(key);
@@ -382,12 +384,8 @@ class XSenseApp extends Homey.App {
           continue;
         }
 
-        // Check if MQTT is healthy for all houses of this client
-        const houses = Array.from(client.houses.values());
-        const needsPolling = houses.some(house => {
-          const isHealthy = this.mqttHealthy.get(house.houseId);
-          return isHealthy !== true; // Poll if unhealthy or unknown
-        });
+        // Ignore account houses without a paired Homey device/MQTT client.
+        const needsPolling = shouldPollForMQTT(client, this.mqttHealthy);
 
         const now = Date.now();
         const lastPoll = this.lastControlPoll.get(key) || 0;
@@ -415,8 +413,11 @@ class XSenseApp extends Homey.App {
    * Called by XSenseAPI when MQTT connects/disconnects
    */
   setMQTTHealth(houseId, isHealthy) {
+    const previous = this.mqttHealthy.get(houseId);
     this.mqttHealthy.set(houseId, isHealthy);
-    this.log(`MQTT health for house ${houseId}: ${isHealthy ? 'HEALTHY' : 'UNHEALTHY'}`);
+    if (previous !== isHealthy) {
+      this.log(`MQTT health changed: ${isHealthy ? 'HEALTHY' : 'UNHEALTHY'}`);
+    }
   }
 
   /**

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.xsense.svenm",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "name": {
@@ -1462,8 +1462,8 @@
     "measure_last_seen": {
       "type": "string",
       "title": {
-        "en": "Last Seen",
-        "de": "Zuletzt gesehen"
+        "en": "Last Device Report",
+        "de": "Letzter Gerätebericht"
       },
       "getable": true,
       "setable": false,

--- a/drivers/smoke-detector/device.js
+++ b/drivers/smoke-detector/device.js
@@ -166,7 +166,6 @@ class SmokeDetectorDevice extends XSenseDeviceBase {
         }
       }
 
-      this.log('Smoke detector device update completed');
     } catch (error) {
       this.error('Error handling smoke detector device update:', error);
     }

--- a/drivers/temperature-sensor/device.js
+++ b/drivers/temperature-sensor/device.js
@@ -65,8 +65,11 @@ class TemperatureSensorDevice extends XSenseDeviceBase {
         if (temp !== undefined && temp !== null) {
           const parsed = parseFloat(temp);
           if (!Number.isNaN(parsed)) {
-            await this.setCapabilityValue('measure_temperature', parsed).catch(this.error);
-            this.log(`Temperature updated: ${parsed}°C`);
+            const current = this.getCapabilityValue('measure_temperature');
+            if (current !== parsed) {
+              await this.setCapabilityValue('measure_temperature', parsed).catch(this.error);
+              this.log(`Temperature updated: ${parsed}°C`);
+            }
           }
           
           // Trigger flow if temperature changed significantly (more than 1°C)
@@ -90,8 +93,11 @@ class TemperatureSensorDevice extends XSenseDeviceBase {
         if (humidity !== undefined && humidity !== null) {
           const parsed = parseFloat(humidity);
           if (!Number.isNaN(parsed)) {
-            await this.setCapabilityValue('measure_humidity', parsed).catch(this.error);
-            this.log(`Humidity updated: ${parsed}%`);
+            const current = this.getCapabilityValue('measure_humidity');
+            if (current !== parsed) {
+              await this.setCapabilityValue('measure_humidity', parsed).catch(this.error);
+              this.log(`Humidity updated: ${parsed}%`);
+            }
           }
           
           // Track previous humidity for change detection

--- a/lib/LatestValueQueue.js
+++ b/lib/LatestValueQueue.js
@@ -1,0 +1,29 @@
+'use strict';
+
+class LatestValueQueue {
+  constructor(handler, delayMs = 50) {
+    this.handler = handler;
+    this.delayMs = delayMs;
+    this.timer = null;
+    this.pendingValue = undefined;
+  }
+
+  push(value) {
+    this.pendingValue = value;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      const pendingValue = this.pendingValue;
+      this.pendingValue = undefined;
+      this.timer = null;
+      this.handler(pendingValue);
+    }, this.delayMs);
+  }
+
+  cancel() {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    this.pendingValue = undefined;
+  }
+}
+
+module.exports = LatestValueQueue;

--- a/lib/MQTTPollingPolicy.js
+++ b/lib/MQTTPollingPolicy.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function activeHouseIds(client) {
+  if (client && typeof client.getActiveMQTTHouseIds === 'function') {
+    return client.getActiveMQTTHouseIds();
+  }
+
+  if (!(client?.mqttClients instanceof Map)) return [];
+
+  const ids = new Set();
+  for (const info of client.mqttClients.values()) {
+    if (info?.house?.houseId) ids.add(info.house.houseId);
+  }
+  return Array.from(ids);
+}
+
+function shouldPollForMQTT(client, healthByHouse) {
+  const houseIds = activeHouseIds(client);
+  if (houseIds.length === 0) return true;
+  return houseIds.some(houseId => healthByHouse.get(houseId) !== true);
+}
+
+module.exports = {
+  activeHouseIds,
+  shouldPollForMQTT,
+};

--- a/lib/SourceTimestamp.js
+++ b/lib/SourceTimestamp.js
@@ -1,0 +1,70 @@
+'use strict';
+
+function parseCompactTimestamp(value) {
+  const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})?$/.exec(value);
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute, second, milliseconds = '0'] = match;
+  const parts = [year, month, day, hour, minute, second, milliseconds].map(Number);
+  const [y, mo, d, h, mi, s, ms] = parts;
+  const date = new Date(Date.UTC(y, mo - 1, d, h, mi, s, ms));
+
+  if (
+    date.getUTCFullYear() !== y ||
+    date.getUTCMonth() !== mo - 1 ||
+    date.getUTCDate() !== d ||
+    date.getUTCHours() !== h ||
+    date.getUTCMinutes() !== mi ||
+    date.getUTCSeconds() !== s ||
+    date.getUTCMilliseconds() !== ms
+  ) {
+    return null;
+  }
+
+  return date.toISOString();
+}
+
+function normalizeSourceTimestamp(raw) {
+  if (raw === undefined || raw === null || raw === '') return null;
+
+  const value = typeof raw === 'string' ? raw.trim() : String(raw);
+  if (!value) return null;
+
+  // X-Sense also reports UTC timestamps as YYYYMMDDHHmmss[SSS].
+  if (/^\d{14}(\d{3})?$/.test(value)) {
+    return parseCompactTimestamp(value);
+  }
+
+  if (/^\d+$/.test(value)) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return null;
+    const millis = numeric > 1e12 ? numeric : numeric * 1000;
+    const date = new Date(millis);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function normalizeLatestSourceTimestamp(values) {
+  let latest = null;
+  let latestMillis = -Infinity;
+
+  for (const value of values) {
+    const normalized = normalizeSourceTimestamp(value);
+    if (!normalized) continue;
+    const millis = Date.parse(normalized);
+    if (millis > latestMillis) {
+      latest = normalized;
+      latestMillis = millis;
+    }
+  }
+
+  return latest;
+}
+
+module.exports = {
+  normalizeLatestSourceTimestamp,
+  normalizeSourceTimestamp,
+};

--- a/lib/XSenseAPI.js
+++ b/lib/XSenseAPI.js
@@ -88,6 +88,8 @@ class XSenseAPI {
     this.devicesBySn = new Map();
     this.stationsBySn = new Map();
     this.shadowFailureCount = new Map();
+    this.recentUpdateEmissions = new Map();
+    this.pendingStationSyncs = new Map();
     this.legacyAccessToken = null;
     this.legacyRefreshToken = null;
     this.legacyUserId = null;
@@ -1092,38 +1094,46 @@ class XSenseAPI {
     if (device.stationId) {
       const station = this.stations.get(device.stationId);
       if (station) {
-        this.debug.log(`[XSenseAPI] Force syncing station ${station.stationSn} for device ${device.deviceSn}`);
-
-        // 1. Fetch Shadows
-        const shadows = await this._getStationShadowData(station);
-
-        // 2. Process Shadows (Update Map)
-        if (shadows) {
-          // Merge station global data
-          Object.assign(station, shadows);
-
-          // If there are device details in shadow (e.g. 2nd_mainpage devs map)
-          if (shadows.devs) {
-            for (const [key, val] of Object.entries(shadows.devs)) {
-              // Find device by SN (key is SN)
-              const targetId = this.devicesBySn.get(key);
-              if (targetId) {
-                const existing = this.devices.get(targetId);
-                const merged = { ...existing, ...val };
-
-                // Sanitize critical fields
-                merged.alarmStatus = DataSanitizer.toInt(merged.alarmStatus);
-                merged.coPpm = DataSanitizer.toInt(merged.coPpm);
-
-                this.devices.set(targetId, merged);
-              }
-            }
-          }
-        }
+        await this._syncStation(station);
         return this.devices.get(deviceId);
       }
     }
     return device;
+  }
+
+  async _syncStation(station) {
+    const key = station.stationId || station.stationSn;
+    const pending = this.pendingStationSyncs.get(key);
+    if (pending) return pending;
+
+    const sync = (async () => {
+      this.debug.log(`[XSenseAPI] Syncing station ${station.stationSn}`);
+      const shadows = await this._getStationShadowData(station);
+      if (!shadows) return;
+
+      Object.assign(station, shadows);
+      if (!shadows.devs) return;
+
+      for (const [serial, value] of Object.entries(shadows.devs)) {
+        const targetId = this.devicesBySn.get(serial);
+        if (!targetId) continue;
+
+        const existing = this.devices.get(targetId);
+        const merged = { ...existing, ...value };
+        merged.alarmStatus = DataSanitizer.toInt(merged.alarmStatus);
+        merged.coPpm = DataSanitizer.toInt(merged.coPpm);
+        this.devices.set(targetId, merged);
+      }
+    })();
+
+    this.pendingStationSyncs.set(key, sync);
+    try {
+      await sync;
+    } finally {
+      if (this.pendingStationSyncs.get(key) === sync) {
+        this.pendingStationSyncs.delete(key);
+      }
+    }
   }
 
   /**
@@ -3268,6 +3278,16 @@ class XSenseAPI {
   }
 
   _emitUpdate(type, data) {
+    if (type === 'device' && data?.id) {
+      const now = Date.now();
+      const fingerprint = this._createUpdateFingerprint(data);
+      const previous = this.recentUpdateEmissions.get(data.id);
+      if (previous && previous.fingerprint === fingerprint && (now - previous.timestamp) < 2000) {
+        return false;
+      }
+      this.recentUpdateEmissions.set(data.id, { fingerprint, timestamp: now });
+    }
+
     for (const callback of this.updateCallbacks) {
       try {
         callback(type, data);
@@ -3275,6 +3295,29 @@ class XSenseAPI {
         this.debug.error('[XSenseAPI] Update callback error:', error.message);
       }
     }
+    return true;
+  }
+
+  _createUpdateFingerprint(data) {
+    const normalize = (value, key = '') => {
+      if (key === 'lastTempUpdate' && typeof value === 'string') {
+        const timestamp = Date.parse(value);
+        if (Number.isFinite(timestamp)) return Math.floor(timestamp / 1000);
+      }
+      if (Array.isArray(value)) return value.map(item => normalize(item));
+      if (!value || typeof value !== 'object') return value;
+
+      const result = {};
+      for (const childKey of Object.keys(value).sort()) {
+        const normalized = normalize(value[childKey], childKey);
+        if (normalized !== undefined) result[childKey] = normalized;
+      }
+      return result;
+    };
+
+    return crypto.createHash('sha256')
+      .update(JSON.stringify(normalize(data)))
+      .digest('hex');
   }
 
   _resolveHouse(houseId, stationId) {
@@ -3298,6 +3341,14 @@ class XSenseAPI {
       }
     }
     return stations;
+  }
+
+  getActiveMQTTHouseIds() {
+    const houseIds = new Set();
+    for (const info of this.mqttClients.values()) {
+      if (info?.house?.houseId) houseIds.add(info.house.houseId);
+    }
+    return Array.from(houseIds);
   }
 
   _buildStationShadowName(station) {
@@ -3493,6 +3544,8 @@ class XSenseAPI {
     this.houses.clear();
     this.stations.clear();
     this.devices.clear();
+    this.recentUpdateEmissions.clear();
+    this.pendingStationSyncs.clear();
     this.updateCallbacks = [];
   }
   /**

--- a/lib/XSenseDeviceBase.js
+++ b/lib/XSenseDeviceBase.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const { normalizeLatestSourceTimestamp } = require('./SourceTimestamp');
+const LatestValueQueue = require('./LatestValueQueue');
+
 const Homey = require('homey');
 
 /**
@@ -19,6 +22,9 @@ class XSenseDeviceBase extends Homey.Device {
     this.updateDebounceTimers = new Map();
     this.pendingUpdates = new Map();
     this.updateCallback = null; // Callback reference for cleanup
+    this.realtimeTemperatureUpdates = new LatestValueQueue((data) => {
+      this._handleDeviceUpdate(data).catch(error => this.error('Realtime update failed:', error));
+    });
 
     // Default debounce delays (ms)
     this.debounceDelays = {
@@ -32,6 +38,31 @@ class XSenseDeviceBase extends Homey.Device {
 
     // Initialize common device properties
     this._initializeCommon();
+
+    // Capability options are persisted per paired device. Homey only exposes
+    // them after the complete subclass onInit lifecycle has finished.
+    this.ready()
+      .then(() => this._migrateLastReportCapabilityTitle())
+      .catch(error => this.error('Failed to schedule capability title update:', error));
+  }
+
+  async _migrateLastReportCapabilityTitle() {
+    const capabilityId = 'measure_last_seen';
+    if (!this.hasCapability(capabilityId)) return;
+    if (this.getStoreValue('lastReportTitleVersion') === 1) return;
+
+    const expectedTitle = {
+      en: 'Last Device Report',
+      de: 'Letzter Gerätebericht',
+    };
+    try {
+      await this.setCapabilityOptions(capabilityId, {
+        title: expectedTitle,
+      });
+      await this.setStoreValue('lastReportTitleVersion', 1);
+    } catch (error) {
+      this.error('Failed to update last device report title:', error);
+    }
   }
 
   /**
@@ -147,7 +178,6 @@ class XSenseDeviceBase extends Homey.Device {
               this.setStoreValue('deviceSn', updateSn).catch(this.error);
             }
           } else {
-            this.log(`[UpdateCallback] Dropping unmatched update. deviceType=${deviceType || 'unknown'} updateType=${updateType || 'unknown'}`);
             return;
           }
         }
@@ -155,7 +185,12 @@ class XSenseDeviceBase extends Homey.Device {
           this._loggedUpdateMatch = true;
           this.log(`Matched temperature update type=${data.type || data.deviceType || 'unknown'}`);
         }
-        this._handleDeviceUpdate(data).catch((error) => this.error('Realtime update failed:', error));
+        const matchedType = (data.deviceType || data.type || this.deviceData.deviceType || '').toUpperCase();
+        if (matchedType.startsWith('STH') && !data.normalizedEvent) {
+          this.realtimeTemperatureUpdates.push(data);
+        } else {
+          this._handleDeviceUpdate(data).catch((error) => this.error('Realtime update failed:', error));
+        }
       }
     };
 
@@ -345,7 +380,6 @@ class XSenseDeviceBase extends Homey.Device {
       // Update optional diagnostics / parity capabilities
       await this._updateOptionalCapabilities(deviceData);
 
-      this.log('Base device update completed');
     } catch (error) {
       this.error('Error in base _handleDeviceUpdate:', error);
     }
@@ -428,47 +462,30 @@ class XSenseDeviceBase extends Homey.Device {
 
   _getSourceTimestamp(deviceData) {
     const status = deviceData?.status;
-    const raw = this._getFirstValue(deviceData, [
+    const keys = [
       'lastSeen',
       'last_seen',
       'sourceTimestamp',
       'lastTempUpdate',
+      'onlineTime',
+      'onLineTime',
       'updateTime',
       'updatedAt',
       'timestamp',
       'ts',
       'time',
-    ], status);
-
-    if (raw === undefined || raw === null || raw === '') {
-      return null;
-    }
-
-    if (typeof raw === 'number') {
-      const millis = raw > 1e12 ? raw : raw * 1000;
-      const date = new Date(millis);
-      return Number.isNaN(date.getTime()) ? null : date.toISOString();
-    }
-
-    if (typeof raw === 'string') {
-      const trimmed = raw.trim();
-      if (!trimmed) return null;
-
-      if (/^\d+$/.test(trimmed)) {
-        const numeric = Number(trimmed);
-        if (!Number.isFinite(numeric)) return null;
-        const millis = numeric > 1e12 ? numeric : numeric * 1000;
-        const date = new Date(millis);
-        return Number.isNaN(date.getTime()) ? null : date.toISOString();
+    ];
+    const values = [];
+    for (const key of keys) {
+      if (deviceData?.[key] !== undefined && deviceData[key] !== null) {
+        values.push(deviceData[key]);
       }
-
-      const parsed = new Date(trimmed);
-      if (!Number.isNaN(parsed.getTime())) {
-        return parsed.toISOString();
+      if (status?.[key] !== undefined && status[key] !== null) {
+        values.push(status[key]);
       }
     }
 
-    return null;
+    return normalizeLatestSourceTimestamp(values);
   }
 
   _getMQTTConnected() {
@@ -609,6 +626,7 @@ class XSenseDeviceBase extends Homey.Device {
     }
     this.updateDebounceTimers.clear();
     this.pendingUpdates.clear();
+    this.realtimeTemperatureUpdates?.cancel();
 
     // FIX: Remove callback from API to prevent memory leak
     if (this.updateCallback && this.api) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.xsense.svenm",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.xsense.svenm",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "GPL-3.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.xsense.svenm",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "XSense integration for Homey - IMPORTANT: Use dedicated account via Family Share!",
   "main": "app.js",
   "scripts": {

--- a/test/latest-value-queue.test.js
+++ b/test/latest-value-queue.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const LatestValueQueue = require('../lib/LatestValueQueue');
+
+test('coalesces an immediate burst and handles only its latest value', async () => {
+  const handled = [];
+  const queue = new LatestValueQueue(value => handled.push(value), 10);
+
+  queue.push('first');
+  queue.push('second');
+  await new Promise(resolve => setTimeout(resolve, 25));
+
+  assert.deepEqual(handled, ['second']);
+  queue.cancel();
+});
+
+test('cancels a pending value', async () => {
+  const handled = [];
+  const queue = new LatestValueQueue(value => handled.push(value), 10);
+
+  queue.push('pending');
+  queue.cancel();
+  await new Promise(resolve => setTimeout(resolve, 25));
+
+  assert.deepEqual(handled, []);
+});

--- a/test/mqtt-polling-policy.test.js
+++ b/test/mqtt-polling-policy.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { shouldPollForMQTT } = require('../lib/MQTTPollingPolicy');
+
+test('ignores unused account houses when active MQTT houses are healthy', () => {
+  const client = {
+    houses: new Map([
+      ['used', { houseId: 'used' }],
+      ['unused', { houseId: 'unused' }],
+    ]),
+    getActiveMQTTHouseIds: () => ['used'],
+  };
+  const health = new Map([['used', true]]);
+
+  assert.equal(shouldPollForMQTT(client, health), false);
+});
+
+test('polls when an active MQTT house is unhealthy or no MQTT client exists', () => {
+  const health = new Map([['used', false]]);
+
+  assert.equal(shouldPollForMQTT({ getActiveMQTTHouseIds: () => ['used'] }, health), true);
+  assert.equal(shouldPollForMQTT({ getActiveMQTTHouseIds: () => [] }, health), true);
+});

--- a/test/source-timestamp.test.js
+++ b/test/source-timestamp.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  normalizeLatestSourceTimestamp,
+  normalizeSourceTimestamp,
+} = require('../lib/SourceTimestamp');
+
+test('parses X-Sense compact timestamps instead of treating them as Unix milliseconds', () => {
+  assert.equal(
+    normalizeSourceTimestamp(20260717011325),
+    '2026-07-17T01:13:25.000Z'
+  );
+  assert.equal(
+    normalizeSourceTimestamp('20260717011325325'),
+    '2026-07-17T01:13:25.325Z'
+  );
+});
+
+test('continues to parse Unix and ISO timestamps', () => {
+  assert.equal(normalizeSourceTimestamp(1768438611), '2026-01-15T00:56:51.000Z');
+  assert.equal(normalizeSourceTimestamp(1768438611325), '2026-01-15T00:56:51.325Z');
+  assert.equal(normalizeSourceTimestamp('2026-01-15T00:56:51Z'), '2026-01-15T00:56:51.000Z');
+});
+
+test('rejects invalid compact timestamps', () => {
+  assert.equal(normalizeSourceTimestamp('20260230010101'), null);
+});
+
+test('uses the newest device report timestamp across X-Sense fields', () => {
+  assert.equal(
+    normalizeLatestSourceTimestamp([
+      '20260717011325',
+      '20260802062713',
+      null,
+    ]),
+    '2026-08-02T06:27:13.000Z'
+  );
+});

--- a/test/station-sync-dedupe.test.js
+++ b/test/station-sync-dedupe.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const XSenseAPI = require('../lib/XSenseAPI');
+
+const quietHomey = {
+  app: {
+    log() {},
+    error() {},
+  },
+};
+
+test('shares one station cloud request between concurrent device syncs', async () => {
+  const api = new XSenseAPI('test@example.test', 'secret', quietHomey);
+  const station = { stationId: 'station-1', stationSn: 'base-1' };
+  api.stations.set(station.stationId, station);
+  api.devices.set('device-1', { id: 'device-1', deviceSn: 'sensor-1', stationId: station.stationId });
+  api.devices.set('device-2', { id: 'device-2', deviceSn: 'sensor-2', stationId: station.stationId });
+  api.devicesBySn.set('sensor-1', 'device-1');
+  api.devicesBySn.set('sensor-2', 'device-2');
+
+  let requestCount = 0;
+  let releaseRequest;
+  api._getStationShadowData = async () => {
+    requestCount += 1;
+    await new Promise(resolve => { releaseRequest = resolve; });
+    return {
+      devs: {
+        'sensor-1': { temperature: 20 },
+        'sensor-2': { temperature: 21 },
+      },
+    };
+  };
+
+  const first = api.syncDevice('device-1');
+  const second = api.syncDevice('device-2');
+  assert.equal(requestCount, 1);
+
+  releaseRequest();
+  const [firstDevice, secondDevice] = await Promise.all([first, second]);
+  assert.equal(firstDevice.temperature, 20);
+  assert.equal(secondDevice.temperature, 21);
+
+  api.destroy();
+});

--- a/test/update-emission-dedupe.test.js
+++ b/test/update-emission-dedupe.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const XSenseAPI = require('../lib/XSenseAPI');
+
+const quietHomey = {
+  app: {
+    log() {},
+    error() {},
+  },
+};
+
+test('suppresses immediate duplicate device updates but preserves changes', () => {
+  const api = new XSenseAPI('test@example.test', 'secret', quietHomey);
+  const updates = [];
+  api.onUpdate((type, data) => updates.push({ type, data }));
+
+  assert.equal(api._emitUpdate('device', { id: 'sensor-1', temperature: 20, lastTempUpdate: '2026-08-02T07:00:00.100Z' }), true);
+  assert.equal(api._emitUpdate('device', { id: 'sensor-1', temperature: 20, lastTempUpdate: '2026-08-02T07:00:00.900Z' }), false);
+  assert.equal(api._emitUpdate('device', { id: 'sensor-1', temperature: 21, lastTempUpdate: '2026-08-02T07:00:01.000Z' }), true);
+  assert.equal(updates.length, 2);
+
+  api.destroy();
+});
+
+test('allows the same report again after the duplicate window', () => {
+  const api = new XSenseAPI('test@example.test', 'secret', quietHomey);
+  let updateCount = 0;
+  api.onUpdate(() => { updateCount += 1; });
+
+  api._emitUpdate('device', { id: 'sensor-1', humidity: 50 });
+  api.recentUpdateEmissions.get('sensor-1').timestamp -= 2000;
+  api._emitUpdate('device', { id: 'sensor-1', humidity: 50 });
+  assert.equal(updateCount, 2);
+
+  api.destroy();
+});


### PR DESCRIPTION
## Summary
- parse X-Sense compact report timestamps correctly and rename the capability label
- share concurrent station syncs and coalesce duplicate temperature reports
- ignore unrelated listener updates and suppress unchanged capability writes
- skip fallback polling when MQTT is healthy for all active houses
- bump the app to 1.1.13

## Verification
- 23 automated tests pass
- Homey validation passes at publish level
- locally tested on Homey through a complete MQTT/polling cycle without runtime errors