### PR TITLE
Coordinate periodic station polling

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.xsense.svenm",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "name": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 1.1.14
+
+- Share periodic cloud updates between devices on the same station.
+- Throttle fallback discovery and run it only while MQTT is unhealthy.
+
 ## Version 1.1.13
 
 - Correct X-Sense compact timestamps and rename the value to "Last Device Report".

--- a/app.js
+++ b/app.js
@@ -2,7 +2,10 @@
 
 const Homey = require('homey');
 const XSenseAPI = require('./lib/XSenseAPI');
-const { shouldPollForMQTT } = require('./lib/MQTTPollingPolicy');
+const {
+  isFallbackPollDue,
+  shouldPollForMQTT,
+} = require('./lib/MQTTPollingPolicy');
 
 class XSenseApp extends Homey.App {
   /**
@@ -389,15 +392,22 @@ class XSenseApp extends Homey.App {
 
         const now = Date.now();
         const lastPoll = this.lastControlPoll.get(key) || 0;
-        const healthyControlPollDue = (now - lastPoll) >= 300000;
-        if (needsPolling || healthyControlPollDue) {
-          this.log(`Polling updates for client (${needsPolling ? 'MQTT unhealthy or unknown' : 'scheduled control poll'})`);
+        const fallbackPollDue = isFallbackPollDue(
+          client,
+          this.mqttHealthy,
+          lastPoll,
+          now,
+        );
+        if (fallbackPollDue) {
+          this.log('Polling updates for client (MQTT unhealthy or unknown)');
           await client.getAllDevices();
           this.lastControlPoll.set(key, now);
         } else {
           // Log less frequently (only every 10 minutes)
           if (!this._lastSkipLog || (Date.now() - this._lastSkipLog) > 600000) {
-            this.log('Skipping poll - MQTT is healthy for all houses');
+            this.log(needsPolling
+              ? 'Skipping fallback poll - retry interval has not elapsed'
+              : 'Skipping poll - MQTT is healthy for all houses');
             this._lastSkipLog = Date.now();
           }
         }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.xsense.svenm",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "name": {

--- a/lib/MQTTPollingPolicy.js
+++ b/lib/MQTTPollingPolicy.js
@@ -20,7 +20,12 @@ function shouldPollForMQTT(client, healthByHouse) {
   return houseIds.some(houseId => healthByHouse.get(houseId) !== true);
 }
 
+function isFallbackPollDue(client, healthByHouse, lastPoll, now, intervalMs = 300000) {
+  return shouldPollForMQTT(client, healthByHouse) && (now - lastPoll) >= intervalMs;
+}
+
 module.exports = {
   activeHouseIds,
+  isFallbackPollDue,
   shouldPollForMQTT,
 };

--- a/lib/XSenseAPI.js
+++ b/lib/XSenseAPI.js
@@ -1109,10 +1109,10 @@ class XSenseAPI {
     const sync = (async () => {
       this.debug.log(`[XSenseAPI] Syncing station ${station.stationSn}`);
       const shadows = await this._getStationShadowData(station);
-      if (!shadows) return;
+      if (!shadows) return null;
 
       Object.assign(station, shadows);
-      if (!shadows.devs) return;
+      if (!shadows.devs) return shadows;
 
       for (const [serial, value] of Object.entries(shadows.devs)) {
         const targetId = this.devicesBySn.get(serial);
@@ -1124,6 +1124,7 @@ class XSenseAPI {
         merged.coPpm = DataSanitizer.toInt(merged.coPpm);
         this.devices.set(targetId, merged);
       }
+      return shadows;
     })();
 
     this.pendingStationSyncs.set(key, sync);
@@ -1156,7 +1157,7 @@ class XSenseAPI {
 
     // Fetch shadow data to update cache
     try {
-      await this._getStationShadowData(station);
+      await this._syncStation(station);
     } catch (err) {
       this.debug.log('[WARN]', `[XSenseAPI] Failed to update shadow for station ${stationId}:`, err);
     }
@@ -1187,7 +1188,7 @@ class XSenseAPI {
       return {};
     }
 
-    return await this._getStationShadowData(station);
+    return (await this._syncStation(station)) || {};
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.xsense.svenm",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.xsense.svenm",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "license": "GPL-3.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.xsense.svenm",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "XSense integration for Homey - IMPORTANT: Use dedicated account via Family Share!",
   "main": "app.js",
   "scripts": {

--- a/test/mqtt-polling-policy.test.js
+++ b/test/mqtt-polling-policy.test.js
@@ -2,7 +2,10 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { shouldPollForMQTT } = require('../lib/MQTTPollingPolicy');
+const {
+  isFallbackPollDue,
+  shouldPollForMQTT,
+} = require('../lib/MQTTPollingPolicy');
 
 test('ignores unused account houses when active MQTT houses are healthy', () => {
   const client = {
@@ -22,4 +25,15 @@ test('polls when an active MQTT house is unhealthy or no MQTT client exists', ()
 
   assert.equal(shouldPollForMQTT({ getActiveMQTTHouseIds: () => ['used'] }, health), true);
   assert.equal(shouldPollForMQTT({ getActiveMQTTHouseIds: () => [] }, health), true);
+});
+
+test('throttles fallback polling while MQTT remains unhealthy', () => {
+  const client = { getActiveMQTTHouseIds: () => ['used'] };
+  const health = new Map([['used', false]]);
+  const now = 1_000_000;
+
+  assert.equal(isFallbackPollDue(client, health, now - 299999, now), false);
+  assert.equal(isFallbackPollDue(client, health, now - 300000, now), true);
+  health.set('used', true);
+  assert.equal(isFallbackPollDue(client, health, 0, now), false);
 });

--- a/test/station-sync-dedupe.test.js
+++ b/test/station-sync-dedupe.test.js
@@ -44,3 +44,33 @@ test('shares one station cloud request between concurrent device syncs', async (
 
   api.destroy();
 });
+
+test('shares one station cloud request between concurrent device polls', async () => {
+  const api = new XSenseAPI('test@example.test', 'secret', quietHomey);
+  const station = {
+    stationId: 'station-1',
+    stationSn: 'base-1',
+    category: 'SBS50',
+  };
+  api.stations.set(station.stationId, station);
+  api.devices.set('device-1', { id: 'device-1', stationId: station.stationId });
+
+  let requestCount = 0;
+  let releaseRequest;
+  api._getStationShadowData = async () => {
+    requestCount += 1;
+    await new Promise(resolve => { releaseRequest = resolve; });
+    return {};
+  };
+
+  const first = api.getDevices(station.stationId);
+  const second = api.getDevices(station.stationId);
+  assert.equal(requestCount, 1);
+
+  releaseRequest();
+  const [firstResult, secondResult] = await Promise.all([first, second]);
+  assert.equal(firstResult.length, 1);
+  assert.equal(secondResult.length, 1);
+
+  api.destroy();
+});


### PR DESCRIPTION
## Summary
- share periodic cloud requests between devices on the same station
- run fallback discovery only while MQTT is unhealthy
- throttle fallback discovery to once every five minutes
- bump the app to 1.1.14

## Verification
- 25 automated tests pass
- Homey validation passes at publish level
- six-minute Homey runtime test completed without duplicate station requests or runtime errors